### PR TITLE
Add: add account field to playerentity

### DIFF
--- a/SynapseClient/Client/Entities/PlayerEntity.cs
+++ b/SynapseClient/Client/Entities/PlayerEntity.cs
@@ -7,8 +7,9 @@ public class PlayerEntity : PlayerEntityCommon
 
     public PlayerEntity(
         Components? components_ = null,
+        string account_ = "",
         StringNode? name_ = null, IntNode? money_ = null
-    ) : base(components_, name_, money_) { }
+    ) : base(components_, account_, name_, money_) { }
 
     #region REGION_IDENTIFICATION
 

--- a/SynapseCommon/Common/Entities/PlayerEntity.cs
+++ b/SynapseCommon/Common/Entities/PlayerEntity.cs
@@ -3,21 +3,24 @@ using System.Xml.Linq;
 
 public class PlayerEntityCommon : Entity
 {
+    protected string account = "";
     protected StringNode name = new StringNode();
     protected IntNode money = new IntNode();
 
     protected PlayerEntityCommon(
         Components? components_ = null,
+        string account_ = "",
         StringNode? name_ = null, IntNode? money_ = null
     ) : base(components_)
     {
+        account = account_;
         if (name_ != null) name = name_;
         if (money_ != null) money = money_;
     }
 
     public override string ToString()
     {
-        return $"{this.GetType().Name}(name: {name}, money: {money}, )";
+        return $"{this.GetType().Name}(account: {account}, name: {name}, money: {money}, )";
     }
 
     #region REGION_IDENTIFICATION
@@ -40,6 +43,7 @@ public class PlayerEntityCommon : Entity
     {
         List<object> argsList = new List<object>();
         argsList.Add(components.Copy());
+        argsList.Add(account);
         argsList.Add(name.Copy());
         argsList.Add(money.Copy());
         return argsList.ToArray();
@@ -53,6 +57,7 @@ public class PlayerEntityCommon : Entity
     {
         writer.Write(nodeType);
         NodeStreamer.Serialize(components, writer, proxyId);
+        writer.Write(account);
         NodeStreamer.Serialize(name, writer, proxyId);
         NodeStreamer.Serialize(money, writer, proxyId);
     }
@@ -65,6 +70,7 @@ public class PlayerEntityCommon : Entity
     {
         List<object> argsList = new List<object>();
         argsList.Add(NodeStreamer.Deserialize(reader));
+        argsList.Add(reader.ReadString());
         argsList.Add(NodeStreamer.Deserialize(reader));
         argsList.Add(NodeStreamer.Deserialize(reader));
         return argsList.ToArray();
@@ -74,19 +80,14 @@ public class PlayerEntityCommon : Entity
 
     #region REGION_API
 
-    public void SetName(string name_)
+    public string GetAccount()
     {
-        name.Set(name_);
+        return account;
     }
 
     public string GetName()
     {
         return name.Get();
-    }
-
-    public void SetMoney(int money_)
-    {
-        money.Set(money_);
     }
 
     public int GetMoney()
@@ -108,40 +109,6 @@ public static class GmShowPlayer
         if (player != null)
         {
             Log.Debug($"{player}");
-        }
-    }
-}
-
-#endif
-
-#if DEBUG
-
-[RegisterGm]
-public static class GmSetPlayerName
-{
-    public static void Execute(string playerId, string name)
-    {
-        PlayerEntity? player = Game.Instance.GetManager<EntityManager>()?.GetPlayerEntity(playerId);
-        if (player != null)
-        {
-            player.SetName(name);
-        }
-    }
-}
-
-#endif
-
-#if DEBUG
-
-[RegisterGm]
-public static class GmSetPlayerMoney
-{
-    public static void Execute(string playerId, int money)
-    {
-        PlayerEntity? player = Game.Instance.GetManager<EntityManager>()?.GetPlayerEntity(playerId);
-        if (player != null)
-        {
-            player.SetMoney(money);
         }
     }
 }

--- a/SynapseServer/Server/Entities/PlayerEntity.cs
+++ b/SynapseServer/Server/Entities/PlayerEntity.cs
@@ -7,8 +7,9 @@ public class PlayerEntity : PlayerEntityCommon
 
     public PlayerEntity(
         Components? components_ = null,
+        string account_ = "",
         StringNode? name_ = null, IntNode? money_ = null
-    ) : base(components_, name_, money_)
+    ) : base(components_, account_, name_, money_)
     {
         name.SetNodeSyncType(NodeSyncConst.SyncAll);
         name.Set("Name");
@@ -49,4 +50,57 @@ public class PlayerEntity : PlayerEntityCommon
     }
 
     #endregion
+
+    #region REGION_API
+
+    public void SetAccount(string account_)
+    {
+        account = account_;
+    }
+
+    public void SetName(string name_)
+    {
+        name.Set(name_);
+    }
+
+    public void SetMoney(int money_)
+    {
+        money.Set(money_);
+    }
+
+    #endregion
 }
+
+#if DEBUG
+
+[RegisterGm]
+public static class GmSetPlayerName
+{
+    public static void Execute(string playerId, string name)
+    {
+        PlayerEntity? player = Game.Instance.GetManager<EntityManager>()?.GetPlayerEntity(playerId);
+        if (player != null)
+        {
+            player.SetName(name);
+        }
+    }
+}
+
+#endif
+
+#if DEBUG
+
+[RegisterGm]
+public static class GmSetPlayerMoney
+{
+    public static void Execute(string playerId, int money)
+    {
+        PlayerEntity? player = Game.Instance.GetManager<EntityManager>()?.GetPlayerEntity(playerId);
+        if (player != null)
+        {
+            player.SetMoney(money);
+        }
+    }
+}
+
+#endif

--- a/SynapseServer/Server/Managers/EntityManager.cs
+++ b/SynapseServer/Server/Managers/EntityManager.cs
@@ -58,6 +58,7 @@ public class EntityManager : EntityManagerCommon
         accountWithPlayerId.Add(account, playerId);
         playerEntities.Add(playerId, player);
         player.SetId(playerId);
+        player.SetAccount(account);
         AccountManager? accountManager = Game.Instance.GetManager<AccountManager>();
         if (accountManager != null)
         {


### PR DESCRIPTION
This PR includes the following features:
- Add ```account``` to player entity as a common field
- ```account``` will be synchronized from server to client when player entity is synchronized
- ```account``` will not be synchronized to client when changed. ```account``` is supposed to be set only when right after server new.
- Setters of player entity are changed to be server only.